### PR TITLE
list view for muscle group is complete and runs successfully

### DIFF
--- a/simplefitapi/views/muscle_group_views.py
+++ b/simplefitapi/views/muscle_group_views.py
@@ -1,0 +1,17 @@
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from simplefitapi.models import MuscleGroup
+
+class MuscleGroupView(ViewSet):
+    """list view for descriptions"""
+    def list (self, request):
+        muscle_group = MuscleGroup.objects.all()
+        serialized = MuscleGroupSerializer(muscle_group, many = True)
+        return Response(serialized.data)
+
+class MuscleGroupSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = MuscleGroup
+        fields = ('id', 'muscle_group')

--- a/simplefitproject/urls.py
+++ b/simplefitproject/urls.py
@@ -3,10 +3,12 @@ from django.urls import include, path
 from rest_framework import routers
 from simplefitapi.views.workout_views import WorkoutView
 from simplefitapi.views.description_views import DescriptionView
+from simplefitapi.views.muscle_group_views import MuscleGroupView
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'workouts', WorkoutView, 'workout')
 router.register(r'descriptions', DescriptionView, 'description')
+router.register(r'muscle_groups', MuscleGroupView, 'muscle_group')
 
 urlpatterns = [
     path('', include(router.urls)),


### PR DESCRIPTION
## Changes
- Added list method for muscle groups. Now all muscle groups are available to view upon request.

## Responses

Successful GET Request (List method for all muscle groups) for http://localhost:8000/muscle_groups:

```json
[
    {
        "id": 1,
        "muscle_group": "Back"
    },
    {
        "id": 2,
        "muscle_group": "Arms"
    },
    {
        "id": 3,
        "muscle_group": "Legs"
    },
    {
        "id": 4,
        "muscle_group": "Chest"
    },
    {
        "id": 5,
        "muscle_group": "Abs"
    }
]
```